### PR TITLE
Checksum crc32

### DIFF
--- a/inet.cpp
+++ b/inet.cpp
@@ -17,9 +17,11 @@
 uint16_t htons(uint16_t v) {
   return (v >> 8) | (v << 8);
 }
-uint32_t htonl(uint32_t v) {
-  return htons(v >> 16) | (htons((uint16_t) v) << 16);
-}
+/*uint32_t htonl(uint32_t v) {
+  unsigned char *s = (unsigned char *)&v;
+  return (uint32_t)(s[0] << 24 | s[1] << 16 | s[2] << 8 | s[3]);
+  //return htons(v >> 16) | (htons((uint16_t) v) << 16);
+}*/
 
 #else
 

--- a/inet.hpp
+++ b/inet.hpp
@@ -18,7 +18,11 @@ extern "C" {
 uint16_t htons(uint16_t v);
 
 /* host-to-network long*/
-uint32_t htonl(uint32_t v);
+//uint32_t htonl(uint32_t v);
+#define htonl(x) ( ((x)<<24 & 0xFF000000UL) | \
+                   ((x)<< 8 & 0x00FF0000UL) | \
+                   ((x)>> 8 & 0x0000FF00UL) | \
+                   ((x)>>24 & 0x000000FFUL) )
 
 /* network-to-host short*/
 uint16_t ntohs(uint16_t v);

--- a/lib_test.ino
+++ b/lib_test.ino
@@ -83,20 +83,6 @@ void loop() {
 
   message_free(&msg);
 
-
-  uint8_t byteBuffer[] = "Hello World";
-  uint8_t *value = byteBuffer;
-
-  uint32_t checksum = 0;
-  checksum = crc32(checksum, value, (size_t)sizeof(byteBuffer));
-    //Serial.println(checksum);
-
-  Serial.println(checksum, HEX);
-
-  checksum = htonl(checksum);
-
-  Serial.println(checksum, HEX);
-
   Serial.println("end");
   while(1);
 }

--- a/lib_test.ino
+++ b/lib_test.ino
@@ -1,7 +1,7 @@
 
 #include "message.hpp"
 #include "frame.hpp"
-#include "crc32.hpp"
+//#include "crc32.hpp"
 #include "inet.hpp"
 
 void setup() {
@@ -19,13 +19,13 @@ void loop() {
   message_init(&msg);
   //Serial.print("msg sizeof: ");
   //Serial.println(sizeof(msg));
-  message_tlv_add_command(&msg, COMMAND_GET_STATUS);
+  //message_tlv_add_command(&msg, COMMAND_GET_STATUS);
   //Serial.print("msg sizeof: ");
   //Serial.println(sizeof(msg));
-  //message_tlv_add_command(&msg, COMMAND_MOVE_MOTOR);
+  message_tlv_add_command(&msg, COMMAND_MOVE_MOTOR);
   //message_tlv_add_reply(&msg, REPLY_ERROR_REPORT);
-  //tlv_motor_position_t position = {0, 0, 0};
-  //message_tlv_add_motor_position(&msg, &position);
+  tlv_motor_position_t position = {1000, 0, 0};
+  message_tlv_add_motor_position(&msg, &position);
 
   uint8_t buffer[1024];
   size_t length = message_serialize(buffer, 1024, &msg);

--- a/message.cpp
+++ b/message.cpp
@@ -17,7 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "message.hpp"
-#include "crc32.hpp"
+//#include "crc32.hpp"
+/*Lib for CRC32 https://github.com/bakercp/CRC32 */
 #include "CRC32.h"
 #include <string.h>
 #include <stdlib.h>

--- a/message.cpp
+++ b/message.cpp
@@ -18,10 +18,11 @@
  */
 #include "message.hpp"
 #include "crc32.hpp"
-
+#include "CRC32.h"
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include "Ethernet.h"
 #include "inet.hpp"
 //#include <arpa/inet.h>
 
@@ -284,12 +285,18 @@ void message_print(const message_t *message)
 
 uint32_t message_checksum(const message_t *message)
 {
+  
   uint32_t checksum = 0;
+  // Create a CRC32 checksum calculator.
+  CRC32 crc;
   for (size_t i = 0; i < message->length; i++) {
-    checksum = crc32(checksum, message->tlv[i].value, message->tlv[i].length);
+    crc.update(message->tlv[i].value, message->tlv[i].length);
+    //checksum = crc32(checksum, message->tlv[i].value, message->tlv[i].length);
     //Serial.print("Voja");
     //Serial.println(checksum);
   }
+  checksum = crc.finalize();
+  //return checksum;
   return htonl(checksum);
 }
 


### PR DESCRIPTION
there was a problem with crc32 calculation, that is why now we use CRC32 library for Arduino from Github https://github.com/bakercp/CRC32 

Also, there was a problem with inet function htonl which was not returning last two bites, when it swaps them. This function is now implemented as macro in inet.h file.